### PR TITLE
Update contact_persons to use the correct model name

### DIFF
--- a/lib/xeroizer/models/contact.rb
+++ b/lib/xeroizer/models/contact.rb
@@ -60,7 +60,7 @@ module Xeroizer
       has_many  :addresses, :list_complete => true
       has_many  :phones, :list_complete => true
       has_many  :contact_groups, :list_complete => true
-      has_many  :contact_persons, :internal_name => :contact_people, :list_complete => true
+      has_many  :contact_persons, :model_name => 'ContactPerson', :list_complete => true
 
       has_many :sales_tracking_categories, :model_name => 'ContactSalesTrackingCategory', :list_complete => true
       has_many :purchases_tracking_categories, :model_name => 'ContactPurchasesTrackingCategory', :list_complete => true


### PR DESCRIPTION
Trying to send contact persons to Xero and was getting the error `NoMethodError: undefined method contact_persons= for an instance of Xeroizer::Record::Contact`

I found this old issue https://github.com/waynerobinson/xeroizer/issues/143 where someone suggested setting the model name to `ContactPerson`. The issue was closed without a fix but I tried this out in our fork and it works. 