### PR TITLE
Allow empty ContactPersons

### DIFF
--- a/lib/xeroizer/record/xml_helper.rb
+++ b/lib/xeroizer/record/xml_helper.rb
@@ -124,6 +124,10 @@ module Xeroizer
                     value.each { | record | record.to_xml(b) }
                   }
                   nil
+                else
+                  return nil unless field[:api_name] == 'ContactPersons'
+                  b.tag!(field[:api_name], nil)
+                  nil
                 end
 
             end


### PR DESCRIPTION
We need to send empty ContactPersons when we want to delete them from Xero.